### PR TITLE
Fix standard options list layout

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -1,0 +1,10 @@
+.standard-options-list {
+  columns: 2;
+  -webkit-columns: 2;
+  -moz-columns: 2;
+  column-gap: 20px;
+  -webkit-column-gap: 20px;
+  -moz-column-gap: 20px;
+  list-style-type: disc;
+  padding-left: 20px;
+}

--- a/templates/fleet_quote_template.html
+++ b/templates/fleet_quote_template.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Fleet Quote</title>
   <link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/static/styles.css">
   <style>
     @page {
       margin: 10mm;
@@ -128,7 +129,7 @@
       </table>
       {% if vehicle.standardOptions %}
       <p><strong>Standard Options:</strong></p>
-      <ul>
+      <ul class="standard-options-list">
         {% for opt in vehicle.standardOptions %}
           <li>{{ opt }}</li>
         {% endfor %}


### PR DESCRIPTION
## Summary
- show vehicle standard options in two columns using external stylesheet

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`

## Summary by Sourcery

Implement two-column layout for vehicle standard options by moving styling to an external stylesheet and updating the template to use it.

Enhancements:
- Add a static stylesheet with CSS columns to format the standard options list into two columns
- Link the external stylesheet in the fleet quote template and apply the "standard-options-list" class to the options <ul>