### PR TITLE
Fix standard options list layout

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -1,0 +1,10 @@
+.standard-options-list {
+  columns: 2;
+  -webkit-columns: 2;
+  -moz-columns: 2;
+  column-gap: 20px;
+  -webkit-column-gap: 20px;
+  -moz-column-gap: 20px;
+  list-style-type: disc;
+  padding-left: 20px;
+}

--- a/templates/fleet_quote_template.html
+++ b/templates/fleet_quote_template.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Fleet Quote</title>
   <link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
   <style>
     @page {
       margin: 10mm;
@@ -128,7 +129,7 @@
       </table>
       {% if vehicle.standardOptions %}
       <p><strong>Standard Options:</strong></p>
-      <ul>
+      <ul class="standard-options-list">
         {% for opt in vehicle.standardOptions %}
           <li>{{ opt }}</li>
         {% endfor %}


### PR DESCRIPTION
## Summary
- show vehicle standard options in two columns using an external stylesheet

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`

## Summary by Sourcery

Improve the layout of vehicle standard options by linking an external stylesheet and rendering the list in two columns.

Enhancements:
- Link a new static stylesheet in the fleet quote template and add a .standard-options-list class to the options <ul>
- Define two-column layout and column gaps for .standard-options-list in static/styles.css