### PR TITLE
Fix standard options list layout

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -1,0 +1,10 @@
+.standard-options-list {
+  columns: 2;
+  -webkit-columns: 2;
+  -moz-columns: 2;
+  column-gap: 20px;
+  -webkit-column-gap: 20px;
+  -moz-column-gap: 20px;
+  list-style-type: disc;
+  padding-left: 20px;
+}

--- a/templates/fleet_quote_template.html
+++ b/templates/fleet_quote_template.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Fleet Quote</title>
   <link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://quote-assets.onrender.com/styles.css">
   <style>
     @page {
       margin: 10mm;
@@ -128,7 +129,7 @@
       </table>
       {% if vehicle.standardOptions %}
       <p><strong>Standard Options:</strong></p>
-      <ul>
+      <ul class="standard-options-list">
         {% for opt in vehicle.standardOptions %}
           <li>{{ opt }}</li>
         {% endfor %}


### PR DESCRIPTION
## Summary
- show vehicle standard options in two columns
- move CSS for standard options into an external stylesheet

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`

## Summary by Sourcery

Extract the standard options CSS into an external stylesheet and update the fleet quote template to apply a two-column layout to the options list

Enhancements:
- Move the standard options styling from inline template CSS into a new external stylesheet
- Add a CSS class to the options <ul> and link the external stylesheet in the fleet quote template to display items in two columns