### PR TITLE
Fix standard options list layout

### DIFF
--- a/templates/fleet_quote_template.html
+++ b/templates/fleet_quote_template.html
@@ -52,6 +52,16 @@
       border-top: 1px solid #ddd;
       margin: 30px 0;
     }
+    .standard-options-list {
+      columns: 2;
+      -webkit-columns: 2;
+      -moz-columns: 2;
+      column-gap: 1em;
+      -webkit-column-gap: 1em;
+      -moz-column-gap: 1em;
+      list-style-type: disc;
+      padding-left: 20px;
+    }
   </style>
 </head>
 <body>
@@ -128,7 +138,7 @@
       </table>
       {% if vehicle.standardOptions %}
       <p><strong>Standard Options:</strong></p>
-      <ul>
+      <ul class="standard-options-list">
         {% for opt in vehicle.standardOptions %}
           <li>{{ opt }}</li>
         {% endfor %}


### PR DESCRIPTION
## Summary
- show vehicle standard options in two columns with column gaps

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`
