### PR TITLE
Fix address formatting in quote template

### DIFF
--- a/templates/fleet_quote_template.html
+++ b/templates/fleet_quote_template.html
@@ -92,22 +92,26 @@
       <th>QUOTE FROM:</th>
       <th>QUOTE FOR:</th>
     </tr>
-    <tr>
-      <td style="vertical-align: top;">
-        <strong>{{ dealership }}</strong><br>
-        {{ managerName }}<br>
-        {{ managerPhone }}<br>
-        {{ managerEmail }}
-      </td>
+      <tr>
         <td style="vertical-align: top;">
-          {% set customer_lines = customer.replace('\r\n', '\n').replace('\r', '\n').split('\n') %}
-          <strong>{{ customer_lines[0] }}</strong><br>
-          {% for line in customer_lines[1:] %}
+          {% set from_lines = dealership.replace('\r\n', '\n').replace('\r', '\n').split('\n') %}
+          <strong>{{ from_lines[0] }}</strong><br>
+          {% for line in from_lines[1:] %}
             {{ line }}<br>
           {% endfor %}
-          {% if customerContactName %}{{ customerContactName }}<br>{% endif %}
-          {% if customerPhone %}{{ customerPhone }}<br>{% endif %}
-          {% if customerEmail %}{{ customerEmail }}<br>{% endif %}
+          {% if managerName %}{{ managerName }}<br>{% endif %}
+          {% if managerPhone %}{{ managerPhone }}<br>{% endif %}
+          {% if managerEmail %}{{ managerEmail }}<br>{% endif %}
+        </td>
+          <td style="vertical-align: top;">
+            {% set customer_lines = customer.replace('\r\n', '\n').replace('\r', '\n').split('\n') %}
+            <strong>{{ customer_lines[0] }}</strong><br>
+            {% for line in customer_lines[1:] %}
+              {{ line }}<br>
+            {% endfor %}
+            {% if customerContactName %}{{ customerContactName }}<br>{% endif %}
+            {% if customerPhone %}{{ customerPhone }}<br>{% endif %}
+            {% if customerEmail %}{{ customerEmail }}<br>{% endif %}
         </td>
       </tr>
     </table>


### PR DESCRIPTION
## Summary
- ensure newline support for Quote From and Quote For sections

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_683b51995d248326807feccea44a39ce

## Summary by Sourcery

Bug Fixes:
- Support multiline dealership and customer addresses in quote template by splitting on newline characters and rendering lines individually