### PR TITLE
Fix validation and address layout

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -16,6 +16,17 @@ paths:
           application/json:
             schema:
               type: object
+              required:
+                - customer
+                - dealership
+                - managerName
+                - managerPhone
+                - managerEmail
+                - customerContactName
+                - customerPhone
+                - customerEmail
+                - vehicles
+                - transport
               properties:
                 quoteNumber:
                   type: string
@@ -29,16 +40,39 @@ paths:
                   type: string
                 dealership:
                   type: string
+                  enum:
+                    - Sames Laredo Chevrolet
+                    - Sames Bastrop Ford
+                    - Sames Bastrop CDJ
+                    - Sames McAllen Ford
                 managerName:
                   type: string
                 managerPhone:
                   type: string
                 managerEmail:
                   type: string
+                customerContactName:
+                  type: string
+                customerPhone:
+                  type: string
+                customerEmail:
+                  type: string
                 vehicles:
                   type: array
                   items:
                     type: object
+                    required:
+                      - year
+                      - make
+                      - model
+                      - contract
+                      - quantity
+                      - msrp
+                      - discountPrice
+                      - taxAndLicense
+                      - totalPrice
+                      - color
+                      - standardOptions
                     properties:
                       year:
                         type: string
@@ -79,6 +113,11 @@ paths:
                         type: number
                 upfitter:
                   type: object
+                  required:
+                    - company
+                    - quoteNumber
+                    - description
+                    - total
                   properties:
                     company:
                       type: string

--- a/templates/fleet_quote_template.html
+++ b/templates/fleet_quote_template.html
@@ -92,22 +92,26 @@
       <th>QUOTE FROM:</th>
       <th>QUOTE FOR:</th>
     </tr>
-    <tr>
-      <td style="vertical-align: top;">
-        <strong>{{ dealership }}</strong><br>
-        {{ managerName }}<br>
-        {{ managerPhone }}<br>
-        {{ managerEmail }}
-      </td>
+      <tr>
         <td style="vertical-align: top;">
-          {% set customer_lines = customer.replace('\r\n', '\n').replace('\r', '\n').split('\n') %}
-          <strong>{{ customer_lines[0] }}</strong><br>
-          {% for line in customer_lines[1:] %}
+          {% set from_lines = dealership.replace('\r\n', '\n').replace('\r', '\n').split('\n') %}
+          <strong>{{ from_lines[0] }}</strong><br>
+          {% for line in from_lines[1:] %}
             {{ line }}<br>
           {% endfor %}
-          {% if customerContactName %}{{ customerContactName }}<br>{% endif %}
-          {% if customerPhone %}{{ customerPhone }}<br>{% endif %}
-          {% if customerEmail %}{{ customerEmail }}<br>{% endif %}
+          {% if managerName %}<strong>Sales Person:</strong> {{ managerName }}<br>{% endif %}
+          {% if managerEmail %}<strong>Email:</strong> {{ managerEmail }}<br>{% endif %}
+          {% if managerPhone %}<strong>Phone:</strong> {{ managerPhone }}<br>{% endif %}
+       </td>
+          <td style="vertical-align: top;">
+            {% set customer_lines = customer.replace('\r\n', '\n').replace('\r', '\n').split('\n') %}
+            <strong>{{ customer_lines[0] }}</strong><br>
+            {% for line in customer_lines[1:] %}
+              {{ line }}<br>
+            {% endfor %}
+            {% if customerContactName %}<strong>Attn:</strong> {{ customerContactName }}<br>{% endif %}
+            {% if customerEmail %}<strong>Email:</strong> {{ customerEmail }}<br>{% endif %}
+            {% if customerPhone %}<strong>Phone:</strong> {{ customerPhone }}<br>{% endif %}
         </td>
       </tr>
     </table>


### PR DESCRIPTION
## Summary
- enforce required fields in OpenAPI spec
- validate incoming JSON in `generate_quote`
- handle quote counter errors and rename files `<quoteNumber>_<Customer>.pdf`
- show labels for contact info in the quote template

## Testing
- `python -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683b51995d248326807feccea44a39ce

## Summary by Sourcery

Enforce payload validation and update the OpenAPI spec, improve error handling for the quote counter, rename output PDF files, and enhance contact labeling in the quote template

Bug Fixes:
- Validate incoming quote JSON and return appropriate 400 errors for missing top-level, vehicle, or upfitter fields
- Handle and report errors when reading or writing the quote counter

Enhancements:
- Rename generated PDF files to `<quoteNumber>_<Customer>.pdf` and sanitize customer names
- Label manager and customer contact fields explicitly in the quote HTML template

Documentation:
- Extend OpenAPI spec to mark required fields on top-level, vehicles, and upfitter objects