### PR TITLE
Improve validation and contact labels

### DIFF
--- a/app.py
+++ b/app.py
@@ -59,6 +59,64 @@ def generate_quote():
         pprint.pprint(data)
         print("========== END DEBUG ==========\n")
 
+        # Validate required fields
+        required = [
+            "customer",
+            "customerContactName",
+            "customerPhone",
+            "customerEmail",
+            "dealership",
+            "managerName",
+            "managerPhone",
+            "managerEmail",
+            "vehicles",
+            "transport",
+        ]
+        missing = [f for f in required if not data.get(f)]
+        if missing:
+            return jsonify({"error": "Missing required field(s)", "fields": missing}), 400
+
+        vehicle_required = [
+            "year",
+            "make",
+            "model",
+            "contract",
+            "quantity",
+            "msrp",
+            "discountPrice",
+            "taxAndLicense",
+            "totalPrice",
+            "color",
+            "standardOptions",
+        ]
+        for idx, vehicle in enumerate(data.get("vehicles", []), start=1):
+            mv = [f for f in vehicle_required if not vehicle.get(f)]
+            if mv:
+                return (
+                    jsonify({"error": f"Vehicle {idx} missing fields", "fields": mv}),
+                    400,
+                )
+
+        if data.get("upfitter"):
+            upfitter_required = ["company", "quoteNumber", "description", "total"]
+            mu = [f for f in upfitter_required if not data["upfitter"].get(f)]
+            if mu:
+                return jsonify({"error": "Upfitter missing fields", "fields": mu}), 400
+
+        for idx, upgrade in enumerate(data.get("upgrades", []), start=1):
+            upgrade_required = ["name", "quantity", "price", "total"]
+            mu = [f for f in upgrade_required if not upgrade.get(f)]
+            if mu:
+                return (
+                    jsonify({"error": f"Upgrade {idx} missing fields", "fields": mu}),
+                    400,
+                )
+
+        transport_required = ["miles", "ratePerMile", "total"]
+        mt = [f for f in transport_required if not data["transport"].get(f)]
+        if mt:
+            return jsonify({"error": "Transport missing fields", "fields": mt}), 400
+
         # Set dates if missing
         if not data.get("quoteDate"):
             data["quoteDate"] = datetime.now().strftime("%Y-%m-%d")
@@ -95,7 +153,8 @@ def generate_quote():
         html_content = template.render(data)
 
         # Submit to DocRaptor
-        filename = f"{data['customer'].replace(' ', '_')}_{data['quoteNumber']}.pdf"
+        safe_customer = data['customer'].replace(' ', '_')
+        filename = f"{data['quoteNumber']}_{safe_customer}.pdf"
         create_resp = requests.post(
             "https://docraptor.com/async_docs",
             auth=(docraptor_api_key, ""),

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -16,6 +16,17 @@ paths:
           application/json:
             schema:
               type: object
+              required:
+                - customer
+                - customerContactName
+                - customerPhone
+                - customerEmail
+                - dealership
+                - managerName
+                - managerPhone
+                - managerEmail
+                - vehicles
+                - transport
               properties:
                 quoteNumber:
                   type: string
@@ -27,8 +38,19 @@ paths:
                   format: date
                 customer:
                   type: string
+                customerContactName:
+                  type: string
+                customerPhone:
+                  type: string
+                customerEmail:
+                  type: string
                 dealership:
                   type: string
+                  enum:
+                    - Sames Laredo Chevrolet
+                    - Sames Bastrop Ford
+                    - Sames Bastrop CDJ
+                    - Sames McAllen Ford
                 managerName:
                   type: string
                 managerPhone:
@@ -39,6 +61,18 @@ paths:
                   type: array
                   items:
                     type: object
+                    required:
+                      - year
+                      - make
+                      - model
+                      - contract
+                      - quantity
+                      - msrp
+                      - discountPrice
+                      - taxAndLicense
+                      - totalPrice
+                      - color
+                      - standardOptions
                     properties:
                       year:
                         type: string
@@ -68,6 +102,11 @@ paths:
                   type: array
                   items:
                     type: object
+                    required:
+                      - name
+                      - quantity
+                      - price
+                      - total
                     properties:
                       name:
                         type: string
@@ -79,6 +118,11 @@ paths:
                         type: number
                 upfitter:
                   type: object
+                  required:
+                    - company
+                    - quoteNumber
+                    - description
+                    - total
                   properties:
                     company:
                       type: string
@@ -90,6 +134,10 @@ paths:
                       type: number
                 transport:
                   type: object
+                  required:
+                    - miles
+                    - ratePerMile
+                    - total
                   properties:
                     miles:
                       type: integer

--- a/templates/fleet_quote_template.html
+++ b/templates/fleet_quote_template.html
@@ -92,22 +92,26 @@
       <th>QUOTE FROM:</th>
       <th>QUOTE FOR:</th>
     </tr>
-    <tr>
-      <td style="vertical-align: top;">
-        <strong>{{ dealership }}</strong><br>
-        {{ managerName }}<br>
-        {{ managerPhone }}<br>
-        {{ managerEmail }}
-      </td>
+      <tr>
         <td style="vertical-align: top;">
-          {% set customer_lines = customer.replace('\r\n', '\n').replace('\r', '\n').split('\n') %}
-          <strong>{{ customer_lines[0] }}</strong><br>
-          {% for line in customer_lines[1:] %}
+          {% set from_lines = dealership.replace('\r\n', '\n').replace('\r', '\n').split('\n') %}
+          <strong>{{ from_lines[0] }}</strong><br>
+          {% for line in from_lines[1:] %}
             {{ line }}<br>
           {% endfor %}
-          {% if customerContactName %}{{ customerContactName }}<br>{% endif %}
-          {% if customerPhone %}{{ customerPhone }}<br>{% endif %}
-          {% if customerEmail %}{{ customerEmail }}<br>{% endif %}
+          {% if managerName %}<strong>Sales Person:</strong> {{ managerName }}<br>{% endif %}
+          {% if managerEmail %}<strong>Email:</strong> {{ managerEmail }}<br>{% endif %}
+          {% if managerPhone %}<strong>Phone:</strong> {{ managerPhone }}<br>{% endif %}
+        </td>
+          <td style="vertical-align: top;">
+            {% set customer_lines = customer.replace('\r\n', '\n').replace('\r', '\n').split('\n') %}
+            <strong>{{ customer_lines[0] }}</strong><br>
+            {% for line in customer_lines[1:] %}
+              {{ line }}<br>
+            {% endfor %}
+            {% if customerContactName %}<strong>Attn:</strong> {{ customerContactName }}<br>{% endif %}
+            {% if customerEmail %}<strong>Email:</strong> {{ customerEmail }}<br>{% endif %}
+            {% if customerPhone %}<strong>Phone:</strong> {{ customerPhone }}<br>{% endif %}
         </td>
       </tr>
     </table>


### PR DESCRIPTION
## Summary
- label contact details in the template
- rename generated PDF as `<quoteNumber>_<customer>.pdf`
- declare required fields with enums in `openapi.yaml`
- validate incoming quote data before creating PDFs

## Testing
- `python -m py_compile app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_683b51995d248326807feccea44a39ce