### PR TITLE
Fix Quote For customer info

### DIFF
--- a/templates/fleet_quote_template.html
+++ b/templates/fleet_quote_template.html
@@ -92,29 +92,28 @@
       <th>QUOTE FROM:</th>
       <th>QUOTE FOR:</th>
     </tr>
-      <tr>
-      <tr>
-        <td style="vertical-align: top;">
-          {% set from_lines = dealership.replace('\r\n', '\n').replace('\r', '\n').split('\n') %}
-          <strong>{{ from_lines[0] }}</strong><br>
-          {% for line in from_lines[1:] %}
-            {{ line }}<br>
-          {% endfor %}
-          {% if managerName %}<strong>Sales Person:</strong> {{ managerName }}<br>{% endif %}
-          {% if managerEmail %}<strong>Email:</strong> {{ managerEmail }}<br>{% endif %}
-          {% if managerPhone %}<strong>Phone:</strong> {{ managerPhone }}<br>{% endif %}
-        </td>
-        <td style="vertical-align: top;">
-          {% set from_lines = dealership.replace('\r\n', '\n').replace('\r', '\n').split('\n') %}
-          <strong>{{ from_lines[0] }}</strong><br>
-          {% for line in from_lines[1:] %}
-            {{ line }}<br>
-          {% endfor %}
-{% if customerContactName %}<strong>Attn:</strong> {{ customerContactName }}<br>{% endif %}
-          {% if customerEmail %}<strong>Email:</strong> {{ customerEmail }}<br>{% endif %}
-          {% if customerPhone %}<strong>Phone:</strong> {{ customerPhone }}<br>{% endif %}
-        </td>
-      </tr>
+    <tr>
+      <td style="vertical-align: top;">
+        {% set from_lines = dealership.replace('\r\n', '\n').replace('\r', '\n').split('\n') %}
+        <strong>{{ from_lines[0] }}</strong><br>
+        {% for line in from_lines[1:] %}
+          {{ line }}<br>
+        {% endfor %}
+        {% if managerName %}<strong>Sales Person:</strong> {{ managerName }}<br>{% endif %}
+        {% if managerEmail %}<strong>Email:</strong> {{ managerEmail }}<br>{% endif %}
+        {% if managerPhone %}<strong>Phone:</strong> {{ managerPhone }}<br>{% endif %}
+      </td>
+      <td style="vertical-align: top;">
+        {% set customer_lines = customer.replace('\r\n', '\n').replace('\r', '\n').split('\n') %}
+        <strong>{{ customer_lines[0] }}</strong><br>
+        {% for line in customer_lines[1:] %}
+          {{ line }}<br>
+        {% endfor %}
+        {% if customerContactName %}<strong>Attn:</strong> {{ customerContactName }}<br>{% endif %}
+        {% if customerEmail %}<strong>Email:</strong> {{ customerEmail }}<br>{% endif %}
+        {% if customerPhone %}<strong>Phone:</strong> {{ customerPhone }}<br>{% endif %}
+      </td>
+    </tr>
     </table>
 
   {% if vehicles %}


### PR DESCRIPTION
## Summary
- correct display of customer info in fleet quote template

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_b_683b6f4ecc4c83268dec0a458345cdb5

## Summary by Sourcery

Fix customer info rendering in fleet quote template by using the correct customer data for the “Quote For” column.

Bug Fixes:
- Use the customer variable instead of dealership to populate the “Quote For” section.
- Split and display customer address lines correctly in the template.