### PR TITLE
Sanitize filename creation

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,6 +6,7 @@ from jinja2 import Environment, FileSystemLoader
 from datetime import datetime, timedelta
 import json
 import pprint
+import re
 
 
 def log_quote_to_google_sheets(data):
@@ -95,7 +96,8 @@ def generate_quote():
         html_content = template.render(data)
 
         # Submit to DocRaptor
-        filename = f"{data['customer'].replace(' ', '_')}_{data['quoteNumber']}.pdf"
+        safe_customer = re.sub(r'[^A-Za-z0-9_-]+', '_', data['customer']).strip('_')
+        filename = f"{safe_customer}_{data['quoteNumber']}.pdf"
         create_resp = requests.post(
             "https://docraptor.com/async_docs",
             auth=(docraptor_api_key, ""),

--- a/tests/test_sanitize.py
+++ b/tests/test_sanitize.py
@@ -1,0 +1,14 @@
+import re
+import unittest
+
+class FilenameSanitizeTest(unittest.TestCase):
+    def test_sanitization(self):
+        customer = 'ACME/Corp\nTest '
+        safe_customer = re.sub(r'[^A-Za-z0-9_-]+', '_', customer).strip('_')
+        filename = f"{safe_customer}_12345.pdf"
+        self.assertEqual(filename, 'ACME_Corp_Test_12345.pdf')
+        self.assertNotRegex(filename, r'[^A-Za-z0-9_.-]')
+        self.assertNotIn('\n', filename)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- sanitize `customer` name when generating filenames
- add a unit test validating sanitization logic

## Testing
- `python -m unittest discover -s tests -v`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_b_684338d4f3148326a1cda7b60e528222

## Summary by Sourcery

Sanitize generated PDF filenames by filtering out invalid characters from customer names and add a unit test to verify this logic.

Enhancements:
- Sanitize customer name when constructing filenames by replacing non-alphanumeric characters with underscores and trimming leading/trailing underscores.

Tests:
- Add unit test to validate filename sanitization logic.