### PR TITLE
Add help-text style

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -38,3 +38,9 @@ textarea {
 button {
   margin-top: 10px;
 }
+
+/* Subtle helper text used on the form */
+.help-text {
+  color: #555;
+  margin: 10px 0;
+}


### PR DESCRIPTION
## Summary
- define `.help-text` in the CSS for subtle guidance text

## Testing
- `python -m flask --app app run` *(fails: No module named flask)*

------
https://chatgpt.com/codex/tasks/task_b_684338dabd488326b2d4806ab492cdad