### PR TITLE
Add quote status instructions and polling

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -32,9 +32,16 @@
   ]
 }</textarea>
     <button id="generateBtn">Generate Quote</button>
+    <p id="statusHelp" class="help-text">
+      After submitting, a JSON response with <code>statusId</code> will appear below.
+      Poll <code>/api/quote-status/&lt;statusId&gt;</code> to monitor progress. When
+      <code>done</code> becomes <code>true</code>, the response will include a
+      <code>download_url</code> for the finished PDF.
+    </p>
     <pre id="response"></pre>
+    <p id="downloadContainer"></p>
   </div>
-<script>
+  <script>
   document.getElementById('generateBtn').addEventListener('click', function() {
     let data;
     try {
@@ -47,14 +54,38 @@
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify(data)
-    }).then(r => r.json())
-      .then(json => {
-        document.getElementById('response').textContent = JSON.stringify(json, null, 2);
-      })
-      .catch(err => {
-        document.getElementById('response').textContent = 'Error: ' + err;
-      });
-  });
+      }).then(r => r.json())
+        .then(json => {
+          document.getElementById('response').textContent = JSON.stringify(json, null, 2);
+          if (json.statusId) {
+            pollStatus(json.statusId);
+          }
+        })
+        .catch(err => {
+          document.getElementById('response').textContent = 'Error: ' + err;
+        });
+    });
+
+    function pollStatus(id) {
+      const downloadEl = document.getElementById('downloadContainer');
+      downloadEl.textContent = 'Checking quote status...';
+      const interval = setInterval(() => {
+        fetch(`/api/quote-status/${id}`)
+          .then(r => r.json())
+          .then(stat => {
+            if (stat.done) {
+              clearInterval(interval);
+              downloadEl.innerHTML = `<a href="${stat.download_url}" download>Download PDF</a>`;
+            } else {
+              downloadEl.textContent = `Status: ${stat.status || 'processing'}`;
+            }
+          })
+          .catch(err => {
+            clearInterval(interval);
+            downloadEl.textContent = 'Error checking status: ' + err;
+          });
+      }, 3000);
+    }
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- update UI instructions for `/api/quote-status/<statusId>`
- show quote status and download link when ready

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_b_684338ec8fa08326812f5bad562214ba

## Summary by Sourcery

Implement client-side polling for quote generation status and update the UI with instructions, status updates, and a download link once the PDF is ready

New Features:
- Add help text guiding users to poll `/api/quote-status/<statusId>` after submitting a quote request
- Implement a `pollStatus` function that periodically fetches quote status and updates the UI
- Display a downloadable PDF link when the quote generation is complete and handle errors during polling