### PR TITLE
Clarify and stabilize quote polling

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -32,9 +32,17 @@
   ]
 }</textarea>
     <button id="generateBtn">Generate Quote</button>
+    <p id="statusHelp" class="help-text">
+      After submitting, a JSON response with <code>statusId</code> will appear below.
+      Poll <code>/api/quote-status/&lt;statusId&gt;</code> to monitor progress. When
+      <code>done</code> becomes <code>true</code>, the response will include a
+      <code>download_url</code> for the finished PDF. A download link will
+      automatically appear below once the file is ready.
+    </p>
     <pre id="response"></pre>
+    <p id="downloadContainer"></p>
   </div>
-<script>
+  <script>
   document.getElementById('generateBtn').addEventListener('click', function() {
     let data;
     try {
@@ -47,14 +55,42 @@
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify(data)
-    }).then(r => r.json())
-      .then(json => {
-        document.getElementById('response').textContent = JSON.stringify(json, null, 2);
-      })
-      .catch(err => {
-        document.getElementById('response').textContent = 'Error: ' + err;
-      });
-  });
+      }).then(r => r.json())
+        .then(json => {
+          document.getElementById('response').textContent = JSON.stringify(json, null, 2);
+          if (json.statusId) {
+            pollStatus(json.statusId);
+          }
+        })
+        .catch(err => {
+          document.getElementById('response').textContent = 'Error: ' + err;
+        });
+    });
+
+    function pollStatus(id) {
+      const downloadEl = document.getElementById('downloadContainer');
+      downloadEl.textContent = 'Checking quote status...';
+      const interval = setInterval(() => {
+        fetch(`/api/quote-status/${id}`)
+          .then(r => r.json())
+          .then(stat => {
+            if (stat.done) {
+              clearInterval(interval);
+              if (stat.download_url) {
+                downloadEl.innerHTML = `<a href="${stat.download_url}" target="_blank">Download PDF</a>`;
+              } else {
+                downloadEl.textContent = 'Quote generation completed but no download URL was provided.';
+              }
+            } else {
+              downloadEl.textContent = `Status: ${stat.status || 'processing'}`;
+            }
+          })
+          .catch(err => {
+            clearInterval(interval);
+            downloadEl.textContent = 'Error checking status: ' + err;
+          });
+      }, 3000);
+    }
 </script>
 </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -77,7 +77,13 @@
             if (stat.done) {
               clearInterval(interval);
               if (stat.download_url) {
-                downloadEl.innerHTML = `<a href="${stat.download_url}" target="_blank">Download PDF</a>`;
+                // Safely create the anchor element to avoid XSS
+                downloadEl.textContent = '';
+                const a = document.createElement('a');
+                a.href = stat.download_url;
+                a.target = '_blank';
+                a.textContent = 'Download PDF';
+                downloadEl.appendChild(a);
               } else {
                 downloadEl.textContent = 'Quote generation completed but no download URL was provided.';
               }


### PR DESCRIPTION
## Summary
- clarify that download link appears when status is done
- show link only when download_url is available
- open the PDF in a new tab

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_b_684338ec8fa08326812f5bad562214ba

## Summary by Sourcery

Clarify status polling instructions and implement client-side polling to automatically fetch quote status, conditionally display a download link when ready, and open the PDF in a new tab

New Features:
- Add client-side polling to monitor quote generation and auto-display the download link upon completion

Enhancements:
- Update UI to include clearer instructions for polling quote status
- Display the download link only when a valid download_url is returned and show a fallback message if absent
- Configure the download link to open the PDF in a new browser tab