### PR TITLE
Clarify and stabilize quote polling

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,6 +6,7 @@ from jinja2 import Environment, FileSystemLoader
 from datetime import datetime, timedelta
 import json
 import pprint
+import re
 
 
 def log_quote_to_google_sheets(data):
@@ -95,7 +96,8 @@ def generate_quote():
         html_content = template.render(data)
 
         # Submit to DocRaptor
-        filename = f"{data['customer'].replace(' ', '_')}_{data['quoteNumber']}.pdf"
+        safe_customer = re.sub(r'[^A-Za-z0-9_-]+', '_', data['customer']).strip('_')
+        filename = f"{safe_customer}_{data['quoteNumber']}.pdf"
         create_resp = requests.post(
             "https://docraptor.com/async_docs",
             auth=(docraptor_api_key, ""),

--- a/static/styles.css
+++ b/static/styles.css
@@ -38,3 +38,19 @@ textarea {
 button {
   margin-top: 10px;
 }
+
+/* Subtle helper text used on the form */
+.help-text {
+  color: #555;
+  margin: 10px 0;
+}
+
+@media (max-width: 600px) {
+  .container {
+    padding: 10px;
+  }
+
+  #logo {
+    max-width: 150px;
+  }
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,12 +2,13 @@
 <html>
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Fleet Quote UI</title>
     <link rel="stylesheet" href="/static/styles.css">
 </head>
 <body>
   <div class="container">
-    <img id="logo" src="/static/logo.png" alt="Company logo">
+    <img id="logo" src="/static/logo.png" alt="Fleet Quote Generator logo">
     <h1>Fleet Quote Generator</h1>
     <p class="help-text">Enter quote data in JSON format using the sample below as a starting point.</p>
     <textarea id="jsonInput">{
@@ -32,9 +33,17 @@
   ]
 }</textarea>
     <button id="generateBtn">Generate Quote</button>
+    <p id="statusHelp" class="help-text">
+      After submitting, a JSON response with <code>statusId</code> will appear below.
+      Poll <code>/api/quote-status/&lt;statusId&gt;</code> to monitor progress. When
+      <code>done</code> becomes <code>true</code>, the response will include a
+<code>download_url</code> for the finished PDF. A download link will
+      automatically appear below once the file is ready.
+    </p>
     <pre id="response"></pre>
+    <p id="downloadContainer"></p>
   </div>
-<script>
+  <script>
   document.getElementById('generateBtn').addEventListener('click', function() {
     let data;
     try {
@@ -47,14 +56,42 @@
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify(data)
-    }).then(r => r.json())
-      .then(json => {
-        document.getElementById('response').textContent = JSON.stringify(json, null, 2);
-      })
-      .catch(err => {
-        document.getElementById('response').textContent = 'Error: ' + err;
-      });
-  });
+      }).then(r => r.json())
+        .then(json => {
+          document.getElementById('response').textContent = JSON.stringify(json, null, 2);
+          if (json.statusId) {
+            pollStatus(json.statusId);
+          }
+        })
+        .catch(err => {
+          document.getElementById('response').textContent = 'Error: ' + err;
+        });
+    });
+
+    function pollStatus(id) {
+      const downloadEl = document.getElementById('downloadContainer');
+      downloadEl.textContent = 'Checking quote status...';
+      const interval = setInterval(() => {
+        fetch(`/api/quote-status/${id}`)
+          .then(r => r.json())
+          .then(stat => {
+            if (stat.done) {
+              clearInterval(interval);
+              if (stat.download_url) {
+                downloadEl.innerHTML = `<a href="${stat.download_url}" target="_blank">Download PDF</a>`;
+              } else {
+                downloadEl.textContent = "Quote generation completed but no download URL was provided.";
+              }
+            } else {
+              downloadEl.textContent = `Status: ${stat.status || 'processing'}`;
+            }
+          })
+          .catch(err => {
+            clearInterval(interval);
+            downloadEl.textContent = 'Error checking status: ' + err;
+          });
+      }, 3000);
+    }
 </script>
 </body>
 </html>

--- a/tests/test_sanitize.py
+++ b/tests/test_sanitize.py
@@ -1,0 +1,14 @@
+import re
+import unittest
+
+class FilenameSanitizeTest(unittest.TestCase):
+    def test_sanitization(self):
+        customer = 'ACME/Corp\nTest '
+        safe_customer = re.sub(r'[^A-Za-z0-9_-]+', '_', customer).strip('_')
+        filename = f"{safe_customer}_12345.pdf"
+        self.assertEqual(filename, 'ACME_Corp_Test_12345.pdf')
+        self.assertNotRegex(filename, r'[^A-Za-z0-9_.-]')
+        self.assertNotIn('\n', filename)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- clarify that download link appears when status is done
- show link only when download_url is available
- open the PDF in a new tab
- restore sanitization, responsive CSS, and tests

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_b_684338ec8fa08326812f5bad562214ba

## Summary by Sourcery

Clarify and stabilize the quote polling and PDF download flow by enhancing the UI with help text, making the layout responsive, implementing automatic status polling with a download link that opens in a new tab, and ensuring safe PDF filenames via sanitization with accompanying tests.

New Features:
- Add automatic polling of quote status to display a download link once the PDF is ready
- Display contextual help text in the UI explaining how to monitor status and download the PDF
- Introduce responsive design via viewport meta tag and CSS media queries for mobile layouts

Bug Fixes:
- Sanitize customer names when generating PDF filenames to prevent invalid characters

Enhancements:
- Open the PDF download link in a new browser tab

Tests:
- Add unit test to verify customer name sanitization for PDF filenames